### PR TITLE
Remove reverse proxy code, update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-cas-proxy
+cas-server
 *.crt
 *.key


### PR DESCRIPTION
This removes the cas reverse proxy code and adds a simple default handler.

Updates .gitignore to ignore cas-server rather than cas-proxy.